### PR TITLE
Replace Select with NativeSelect in widget

### DIFF
--- a/apps/web/src/components/ui/native-select.tsx
+++ b/apps/web/src/components/ui/native-select.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+
+import { cn } from "@/utils/utils";
+
+export interface NativeSelectProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <select
+        className={cn(
+          "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </select>
+    );
+  }
+);
+NativeSelect.displayName = "NativeSelect";
+
+export { NativeSelect };

--- a/apps/web/src/components/workflow/widgets/integration-selector.tsx
+++ b/apps/web/src/components/workflow/widgets/integration-selector.tsx
@@ -2,13 +2,7 @@ import Database from "lucide-react/icons/database";
 import RefreshCw from "lucide-react/icons/refresh-cw";
 
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { NativeSelect } from "@/components/ui/native-select";
 import { useIntegrations } from "@/integrations";
 import { cn } from "@/utils/utils";
 
@@ -30,9 +24,9 @@ function IntegrationSelectorWidget({
 }: IntegrationSelectorWidgetProps) {
   const { integrations, error, isLoading, mutate } = useIntegrations();
 
-  const handleSelect = (integrationId: string) => {
+  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (!readonly) {
-      onChange(integrationId);
+      onChange(e.target.value);
     }
   };
 
@@ -63,33 +57,26 @@ function IntegrationSelectorWidget({
 
   return (
     <div className={cn("p-2", className)}>
-      <Select
+      <NativeSelect
         value={value || ""}
-        onValueChange={handleSelect}
+        onChange={handleSelect}
         disabled={readonly || isLoading}
+        className={cn("text-xs", compact ? "h-7" : "h-8")}
       >
-        <SelectTrigger className={cn("text-xs", compact ? "h-7" : "h-8")}>
-          <SelectValue
-            placeholder={isLoading ? "Loading..." : "Select integration..."}
-          />
-        </SelectTrigger>
-        <SelectContent>
-          {filteredIntegrations?.map((integration) => (
-            <SelectItem
-              key={integration.id}
-              value={integration.id}
-              className="text-xs"
-            >
-              {integration.name}
-            </SelectItem>
-          ))}
-          {filteredIntegrations?.length === 0 && !isLoading && (
-            <SelectItem disabled value="none" className="text-xs">
-              No integrations found
-            </SelectItem>
-          )}
-        </SelectContent>
-      </Select>
+        <option value="" disabled>
+          {isLoading ? "Loading..." : "Select integration..."}
+        </option>
+        {filteredIntegrations?.map((integration) => (
+          <option key={integration.id} value={integration.id}>
+            {integration.name}
+          </option>
+        ))}
+        {filteredIntegrations?.length === 0 && !isLoading && (
+          <option disabled value="none">
+            No integrations found
+          </option>
+        )}
+      </NativeSelect>
     </div>
   );
 }


### PR DESCRIPTION
…rWidget

Replace the complex Radix UI Select component with a simpler NativeSelect component using native HTML <select> elements. This simplifies the code and improves performance by using browser-native controls.

Changes:
- Create new NativeSelect component using native HTML select element
- Update IntegrationSelectorWidget to use NativeSelect instead of Radix Select
- Replace SelectTrigger/SelectContent/SelectItem with native option elements
- Simplify event handler to use native onChange instead of onValueChange

🤖 Generated with [Claude Code](https://claude.com/claude-code)