### PR TITLE
feat(web): auto-select newly added workflow nodes

### DIFF
--- a/apps/web/src/components/workflow/use-workflow-state.ts
+++ b/apps/web/src/components/workflow/use-workflow-state.ts
@@ -603,6 +603,7 @@ export function useWorkflowState({
         id: `${nodeType.type}-${Date.now()}`,
         type: "workflowNode",
         position,
+        selected: true,
         data: {
           name: nodeType.name,
           inputs: nodeType.inputs.map((param) => ({


### PR DESCRIPTION
When a user adds a new node to the workflow canvas, it is now automatically selected. This makes the new node immediately visible and easier to identify without requiring additional zoom or pan animations.
